### PR TITLE
dockerize the tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.10-alpine as build
+
+RUN apk update && apk add git make \
+  && go get -d github.com/jmcfarlane/markdown \
+  && cd $GOPATH/src/github.com/jmcfarlane/markdown \
+  && make get \
+  && make \
+  && mv markdown /usr/local/bin/markdown
+
+FROM golang:1.10-alpine
+
+COPY --from=build /usr/local/bin/markdown /usr/local/bin/markdown
+
+# could be made configurable via arg
+WORKDIR /usr/src/app
+
+ENTRYPOINT ["/usr/local/bin/markdown"]


### PR DESCRIPTION
Dockerfile to encapsulate the tool in a docker container.

In order to use it, you can run the following:

```
# builds the docker image locally
$ docker build -t markdown .

# prints help message
$ docker run --rm -ti markdown:latest "-h"

# mounts the current working directory, exposes port 8080
$ docker run --rm -ti -v `pwd`:/usr/src/app -p 8080:8080 markdown:latest
```

I'm open to any suggestions you have and would be more than happy to update anything that you'd like me to add :)